### PR TITLE
Replace the ' char with %27

### DIFF
--- a/CONTRIB/PRODUCER/scripts/CS_build_stix-from_files.py
+++ b/CONTRIB/PRODUCER/scripts/CS_build_stix-from_files.py
@@ -367,6 +367,9 @@ def main(argv):
 
     # url
     for ioc in listURL:
+        # Replace the ' char with %27
+        ioc = ioc.replace("'", "%27")
+        
         # STIX 1.2
         url = URI()
         url.value = ioc


### PR DESCRIPTION
This replacement avoids an error during the generation of Stix2 file.